### PR TITLE
Fix 'L' key label toggle functionality

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -78,7 +78,7 @@ pub struct LabelSettings {
 impl Default for LabelSettings {
     fn default() -> Self {
         Self {
-            visibility_distance: 15.0,
+            visibility_distance: 10.0,  // Reduced from 15.0 for more noticeable toggle effect
             show_all_labels: false,
         }
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -70,15 +70,14 @@ pub fn toggle_label_visibility(
         return;
     }
     // Toggle show all labels with 'L' key
-    if keyboard_input.pressed(KeyCode::KeyL) {
-        label_settings.show_all_labels = true;
+    if keyboard_input.just_pressed(KeyCode::KeyL) {
+        label_settings.show_all_labels = !label_settings.show_all_labels;
         if let Ok(mut text) = indicator_query.single_mut() {
-            text.0 = "Showing all labels".to_string();
-        }
-    } else {
-        label_settings.show_all_labels = false;
-        if let Ok(mut text) = indicator_query.single_mut() {
-            text.0 = String::new();
+            text.0 = if label_settings.show_all_labels {
+                "Showing all labels".to_string()
+            } else {
+                String::new()
+            };
         }
     }
 }
@@ -108,11 +107,17 @@ pub fn update_node_label_positions(
             *visibility = Visibility::Visible;
 
             // Fade labels based on distance (closer = more opaque)
-            let fade_start = label_settings.visibility_distance * 0.7;
-            let alpha = if distance < fade_start {
+            let alpha = if label_settings.show_all_labels {
+                // When forcing all labels visible, make them fully opaque
                 1.0
             } else {
-                1.0 - ((distance - fade_start) / (label_settings.visibility_distance - fade_start))
+                // Normal distance-based fading
+                let fade_start = label_settings.visibility_distance * 0.7;
+                if distance < fade_start {
+                    1.0
+                } else {
+                    1.0 - ((distance - fade_start) / (label_settings.visibility_distance - fade_start))
+                }
             };
 
             text_color.0 = Color::srgba(1.0, 1.0, 1.0, alpha.clamp(0.0, 1.0));


### PR DESCRIPTION
## Summary
Fixed the 'L' key label toggle that was not having any visible effect.

## Problem
- The 'L' key was using `pressed()` instead of `just_pressed()`, making it only work while held down
- Most labels were already visible within the default 15.0 unit distance, making the toggle effect unnoticeable
- No visual distinction between distance-based and force-all-visible modes

## Solution
- Changed to `just_pressed()` for proper toggle behavior
- Reduced default visibility distance from 15.0 to 10.0 units
- Made all labels fully opaque (alpha=1.0) when `show_all_labels` is true
- Labels now clearly show the difference between the two modes

## Test Results
- L key now properly toggles label visibility on/off
- Clear visual difference: distance-based labels fade at edges, forced labels are fully opaque
- "Showing all labels" indicator appears when active

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>