### PR TITLE
feat: Add visualization support for PlantUML sequence diagram node types

### DIFF
--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -7,11 +7,20 @@ use std::collections::HashMap;
 pub fn get_node_appearance(node_type: Option<&str>) -> (Color, f32) {
     // Returns (color, size_multiplier)
     match node_type {
+        // DOT diagram types
         Some("organization") => (Color::srgb(0.8, 0.2, 0.2), 1.5), // Red, large
         Some("line_of_business") => (Color::srgb(0.8, 0.5, 0.2), 1.2), // Orange
         Some("site") => (Color::srgb(0.2, 0.6, 0.8), 1.0),         // Blue
         Some("team") => (Color::srgb(0.2, 0.8, 0.5), 0.8),         // Green
         Some("user") => (Color::srgb(0.6, 0.4, 0.8), 0.6),         // Purple, small
+        
+        // PlantUML sequence diagram types
+        Some("database") => (Color::srgb(0.2, 0.4, 0.7), 1.0),     // Dark blue
+        Some("actor:participant") => (Color::srgb(0.3, 0.7, 0.3), 0.8), // Green for regular participants
+        Some(t) if t.starts_with("actor:") => (Color::srgb(0.9, 0.6, 0.2), 0.9), // Orange for actors
+        Some("process") => (Color::srgb(0.7, 0.7, 0.2), 0.8),      // Yellow
+        Some("external") => (Color::srgb(0.5, 0.2, 0.7), 0.9),     // Purple
+        
         _ => (Color::srgb(0.5, 0.5, 0.5), 0.7),                    // Gray (default)
     }
 }
@@ -59,11 +68,23 @@ pub fn create_graph_visualization(
 
         // Create mesh based on node type
         let mesh = match node_info.node_type.as_deref() {
+            // DOT diagram shapes
             Some("organization") => meshes.add(Cuboid::new(1.0, 1.0, 1.0)), // Cube
             Some("line_of_business") => meshes.add(Cylinder::new(0.5, 1.0)), // Cylinder
             Some("site") => meshes.add(Torus::new(0.3, 0.5)),               // Torus
             Some("team") => meshes.add(Sphere::new(0.6)),                   // Sphere
             Some("user") => meshes.add(Capsule3d::new(0.3, 0.4)),           // Capsule
+            
+            // PlantUML sequence diagram shapes
+            Some("database") => meshes.add(Cylinder::new(0.6, 0.8)),        // Wide cylinder for DB
+            Some("actor:participant") => meshes.add(Cuboid::new(0.8, 0.8, 0.8)), // Cube for services
+            Some(t) if t.starts_with("actor:") => {
+                // Actor as a humanoid shape (capsule)
+                meshes.add(Capsule3d::new(0.4, 0.6))
+            }
+            Some("process") => meshes.add(Sphere::new(0.5)),                // Sphere for process
+            Some("external") => meshes.add(Torus::new(0.25, 0.5)),          // Torus for external
+            
             _ => meshes.add(Sphere::new(0.5)),                              // Default sphere
         };
 

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -85,7 +85,7 @@ pub fn create_graph_visualization(
             Some("process") => meshes.add(Sphere::new(0.5)), // Sphere for process
             Some("external") => meshes.add(Torus::new(0.25, 0.5)), // Torus for external
 
-            _ => meshes.add(Sphere::new(0.5)), // Default sphere
+            _ => meshes.add(Sphere::new(0.4)), // Default sphere
         };
 
         // Spawn node with appropriate shape

--- a/src/visualization.rs
+++ b/src/visualization.rs
@@ -13,15 +13,15 @@ pub fn get_node_appearance(node_type: Option<&str>) -> (Color, f32) {
         Some("site") => (Color::srgb(0.2, 0.6, 0.8), 1.0),         // Blue
         Some("team") => (Color::srgb(0.2, 0.8, 0.5), 0.8),         // Green
         Some("user") => (Color::srgb(0.6, 0.4, 0.8), 0.6),         // Purple, small
-        
+
         // PlantUML sequence diagram types
-        Some("database") => (Color::srgb(0.2, 0.4, 0.7), 1.0),     // Dark blue
+        Some("database") => (Color::srgb(0.2, 0.4, 0.7), 1.0), // Dark blue
         Some("actor:participant") => (Color::srgb(0.3, 0.7, 0.3), 0.8), // Green for regular participants
         Some(t) if t.starts_with("actor:") => (Color::srgb(0.9, 0.6, 0.2), 0.9), // Orange for actors
-        Some("process") => (Color::srgb(0.7, 0.7, 0.2), 0.8),      // Yellow
-        Some("external") => (Color::srgb(0.5, 0.2, 0.7), 0.9),     // Purple
-        
-        _ => (Color::srgb(0.5, 0.5, 0.5), 0.7),                    // Gray (default)
+        Some("process") => (Color::srgb(0.7, 0.7, 0.2), 0.8),                    // Yellow
+        Some("external") => (Color::srgb(0.5, 0.2, 0.7), 0.9),                   // Purple
+
+        _ => (Color::srgb(0.5, 0.5, 0.5), 0.7), // Gray (default)
     }
 }
 
@@ -74,18 +74,18 @@ pub fn create_graph_visualization(
             Some("site") => meshes.add(Torus::new(0.3, 0.5)),               // Torus
             Some("team") => meshes.add(Sphere::new(0.6)),                   // Sphere
             Some("user") => meshes.add(Capsule3d::new(0.3, 0.4)),           // Capsule
-            
+
             // PlantUML sequence diagram shapes
-            Some("database") => meshes.add(Cylinder::new(0.6, 0.8)),        // Wide cylinder for DB
+            Some("database") => meshes.add(Cylinder::new(0.6, 0.8)), // Wide cylinder for DB
             Some("actor:participant") => meshes.add(Cuboid::new(0.8, 0.8, 0.8)), // Cube for services
             Some(t) if t.starts_with("actor:") => {
                 // Actor as a humanoid shape (capsule)
                 meshes.add(Capsule3d::new(0.4, 0.6))
             }
-            Some("process") => meshes.add(Sphere::new(0.5)),                // Sphere for process
-            Some("external") => meshes.add(Torus::new(0.25, 0.5)),          // Torus for external
-            
-            _ => meshes.add(Sphere::new(0.5)),                              // Default sphere
+            Some("process") => meshes.add(Sphere::new(0.5)), // Sphere for process
+            Some("external") => meshes.add(Torus::new(0.25, 0.5)), // Torus for external
+
+            _ => meshes.add(Sphere::new(0.5)), // Default sphere
         };
 
         // Spawn node with appropriate shape


### PR DESCRIPTION
## Summary
This PR extends the 3D visualization capabilities to support PlantUML sequence diagram node types, providing distinct visual representations for different element types commonly found in sequence diagrams.

## Changes

### Node Appearance (Colors & Sizes)
Added color and size definitions for PlantUML sequence diagram elements in `get_node_appearance()`:
- **database**: Dark blue (0.2, 0.4, 0.7) with standard size
- **actor:participant**: Green (0.3, 0.7, 0.3) for regular service participants
- **actor:*** : Orange (0.9, 0.6, 0.2) for actors with dynamic prefix matching
- **process**: Yellow (0.7, 0.7, 0.2) for process nodes
- **external**: Purple (0.5, 0.2, 0.7) for external systems

### 3D Mesh Shapes
Added corresponding 3D mesh shapes in `create_graph_visualization()`:
- **database**: Wide cylinder shape to represent data storage
- **actor:participant**: Cube shape for service components
- **actor:*** : Capsule shape for humanoid/actor representation
- **process**: Sphere shape for process nodes
- **external**: Torus shape for external systems

### Code Organization
- Added clear comment sections to separate DOT diagram types from PlantUML sequence diagram types
- Maintained backward compatibility with existing DOT diagram visualizations
- Used pattern matching with `starts_with()` for flexible actor type handling

## Test plan
- [ ] Verify existing DOT diagram visualizations still work correctly
- [ ] Test PlantUML sequence diagrams with database nodes
- [ ] Test PlantUML sequence diagrams with various actor types
- [ ] Test PlantUML sequence diagrams with process and external nodes
- [ ] Verify default node appearance for unrecognized types

🤖 Generated with [Claude Code](https://claude.ai/code)